### PR TITLE
Update MARK to include pts, pts_rest keys in marker gene table

### DIFF
--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1001,13 +1001,13 @@ def MARK(data):
   keepG = [key for key,val in vCount.items() if val>2]
   adata = adata[adata.obs[data["grp"][0]].isin(keepG),:]
 
-  if len(adata.obs[data['grp'][0]].unique())<2:
-    return 'ERROR @server: {}'.format('Less than 2 groups in selected cells! Please use DEG for 2 groups')
+  if (len(adata.obs[data['grp'][0]].unique())<2) and (data['markMethod']=="logreg"):
+    return 'ERROR @server: {}'.format('Less than 2 groups in selected cells! Please select a different method or use the DEG interface for 2 groups')
     #return json.dumps([[['name','scores'],['None','0']],Msg('Less than 3 groups in selected cells!Please use DEG for 2 groups')])
 
   sc.tl.rank_genes_groups(adata,groupby=data["grp"][0],n_genes=int(data['geneN']),method=data['markMethod'],pts=True)#
   ppr.pprint(int(data['geneN']))
-  sc.pl.rank_genes_groups(adata,n_genes=int(data['geneN']),ncols=min([2,len(adata.obs[data['grp'][0]].unique())]),show=False)
+  sc.pl.rank_genes_groups(adata,n_genes=int(data['geneN']),ncols=min([3,len(adata.obs[data['grp'][0]].unique())]),show=False)
   fig =plt.gcf()
 
   gScore = adata.uns['rank_genes_groups']

--- a/VIPInterface.py
+++ b/VIPInterface.py
@@ -1001,21 +1001,21 @@ def MARK(data):
   keepG = [key for key,val in vCount.items() if val>2]
   adata = adata[adata.obs[data["grp"][0]].isin(keepG),:]
 
-  if len(adata.obs[data['grp'][0]].unique())<3:
-    return 'ERROR @server: {}'.format('Less than 3 groups in selected cells! Please use DEG for 2 groups')
+  if len(adata.obs[data['grp'][0]].unique())<2:
+    return 'ERROR @server: {}'.format('Less than 2 groups in selected cells! Please use DEG for 2 groups')
     #return json.dumps([[['name','scores'],['None','0']],Msg('Less than 3 groups in selected cells!Please use DEG for 2 groups')])
 
-  sc.tl.rank_genes_groups(adata,groupby=data["grp"][0],n_genes=int(data['geneN']),method=data['markMethod'])#
+  sc.tl.rank_genes_groups(adata,groupby=data["grp"][0],n_genes=int(data['geneN']),method=data['markMethod'],pts=True)#
   ppr.pprint(int(data['geneN']))
-  sc.pl.rank_genes_groups(adata,n_genes=int(data['geneN']),ncols=min([3,len(adata.obs[data['grp'][0]].unique())]),show=False)
+  sc.pl.rank_genes_groups(adata,n_genes=int(data['geneN']),ncols=min([2,len(adata.obs[data['grp'][0]].unique())]),show=False)
   fig =plt.gcf()
 
   gScore = adata.uns['rank_genes_groups']
   #ppr.pprint(gScore)
-  pKeys = [i for i in ['names','scores','logfoldchanges','pvals','pvals_adj'] if i in gScore.keys()]
+  pKeys = [i for i in ['names','scores','logfoldchanges','pvals','pvals_adj','pts','pts_rest'] if i in gScore.keys()]
   scoreM = [pKeys+['Group']]
-  for i in gScore['scores'].dtype.names:
-    for j in range(len(gScore['scores'][i])):
+  for i in gScore['scores'].dtype.names: # iterate over groups
+    for j in range(len(gScore['scores'][i])): # iterate over gene index (int)
       one = []
       for k in pKeys:
         if k=='logfoldchanges':
@@ -1024,6 +1024,8 @@ def MARK(data):
           one += ['%.4E' % gScore[k][i][j]]
         elif k=='scores':
           one += ['%.4f' % gScore[k][i][j]]
+        elif k in ['pts', 'pts_rest']:
+          one += ['%.2f' % gScore[k].at[gScore['names'][i][j], i]]
         else:
           one += [gScore[k][i][j]]
       scoreM += [one+[i]]


### PR DESCRIPTION
These commits modify the server-side Marker Genes callback MARK to return the keys pts, pts_rest along with previously returned statistics. These keys correspond to the fraction of cells in the marked group expressing the gene, and the fraction of cells not in the marked group (_rest) that express the marker, respectively. Together these values help to quantify marker gene specificity. 

These commits also change the minimum number of groups to compare from 3 to 2, the minimum supported by scanpy. 2 group comparisons are not supported by the logreg test, and associated error text has been modified to notify users when they attempt to use it for a 2 group test.  