### PR TITLE
refactor: remove nested css styles

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -538,19 +538,19 @@
           border: none;
           cursor: pointer;
       }
-      figure.zoom{
-          & img:hover{
-            opacity: 0;
-          }
-          img {
-              transition: opacity .5s;
-              display: block;
-              width: 100%;
-          }
-          background-position: 50% 50%;
-          position: relative;
-          overflow: hidden;
-          width: 100%;
+      figure.zoom {
+        background-position: 50% 50%;
+        position: relative;
+        overflow: hidden;
+        width: 100%;
+      }
+      figure.zoom img {
+        transition: opacity .5s;
+        display: block;
+        width: 100%;
+      }
+      figure.zoom img:hover {
+        opacity: 0;
       }
     </style>
   </head>


### PR DESCRIPTION
- removed nested css styles because css nesting is supported from chrome version 112.


To use nested CSS style in Chrome 111 or lower, you may need a transpiler.